### PR TITLE
Add iPadOS-inspired new tab workspace dashboard

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -41,6 +41,7 @@ import CropRecommendation from './components/crop/CropRecommendation';
 import NGOMarketplace from './pages/marketplace/NGOMarketplace';
 import CarbonFootprintCalculator from './pages/carbon/CarbonFootprintCalculator';
 import PestDetection from './pages/pest/PestDetection';
+import IpadWorkspace from './pages/dashboard/IpadWorkspace';
 
 // Check for token in localStorage
 if (localStorage.token) {
@@ -71,6 +72,7 @@ const App = () => {
               <Route exact path="/tools/:toolId" component={ToolDetails} />
               <Route exact path="/carbon-footprint" component={CarbonFootprintCalculator} />
               <Route exact path="/pest-detection" component={PestDetection} />
+              <Route exact path="/workspace" component={IpadWorkspace} />
 
               <PrivateRoute exact path="/profile" component={Profile} />
               <PrivateRoute exact path="/orders/:id" component={OrderDetail} />

--- a/client/src/pages/dashboard/IpadWorkspace.css
+++ b/client/src/pages/dashboard/IpadWorkspace.css
@@ -1,0 +1,458 @@
+.ios-workspace {
+  position: relative;
+  min-height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  background: #ffffff;
+  color: #000000;
+  font-family: 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.ios-background {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(0, 122, 255, 0.18), transparent 55%),
+    radial-gradient(circle at bottom, rgba(52, 199, 89, 0.16), transparent 60%),
+    linear-gradient(145deg, #ffffff 0%, #f5f5f5 100%);
+  z-index: 0;
+}
+
+.ios-status-bar {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 3rem 0.5rem;
+  color: #000000;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+}
+
+.ios-status-icons {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ios-status-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.ios-status-battery {
+  font-variation-settings: 'wght' 550;
+}
+
+.ios-top-bar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem 3rem 1rem;
+}
+
+.ios-title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 600;
+}
+
+.ios-subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 1rem;
+}
+
+.ios-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ios-control-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 12px;
+  border: none;
+  background: rgba(245, 245, 245, 0.85);
+  color: #000000;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.1);
+}
+
+.ios-control-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+}
+
+.ios-primary-button {
+  border: none;
+  border-radius: 12px;
+  background: #007aff;
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 12px 30px rgba(0, 122, 255, 0.35);
+}
+
+.ios-primary-button:hover {
+  background: #0062c4;
+  transform: translateY(-1px);
+}
+
+.ios-secondary-button {
+  border: none;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.08);
+  color: #000000;
+  font-weight: 500;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.ios-secondary-button:hover {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.ios-screen-wrapper {
+  position: relative;
+  z-index: 1;
+  margin: 0 auto;
+  width: min(1200px, 92vw);
+  height: clamp(440px, 55vh, 560px);
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.15);
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(18px);
+  cursor: grab;
+}
+
+.ios-screen-wrapper:active {
+  cursor: grabbing;
+}
+
+.ios-screen-track {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.45s ease;
+}
+
+.ios-screen {
+  min-width: 100%;
+  height: 100%;
+  padding: 2.5rem 3rem;
+  box-sizing: border-box;
+}
+
+.ios-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 2rem 1.75rem;
+  justify-items: center;
+}
+
+.ios-app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+.ios-app-icon {
+  width: 82px;
+  height: 82px;
+  border-radius: 24px;
+  position: relative;
+  background-size: cover;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.ios-app-shine {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 55%);
+  pointer-events: none;
+}
+
+.ios-app-initials {
+  position: relative;
+  z-index: 1;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.ios-app-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.8);
+}
+
+.ios-page-indicator {
+  z-index: 1;
+  margin: 1.5rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.ios-page-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.18);
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.ios-page-dot-active {
+  background: #007aff;
+  transform: scale(1.2);
+}
+
+.ios-dock {
+  position: fixed;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
+  width: min(720px, 90vw);
+  height: 116px;
+  border-radius: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3;
+}
+
+.ios-dock-blur {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(44, 44, 44, 0.72);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(26px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.ios-dock-inner {
+  position: relative;
+  display: flex;
+  gap: 1.75rem;
+  padding: 1.5rem 2.5rem;
+  z-index: 1;
+}
+
+.ios-dock-app {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+}
+
+.ios-dock-app .ios-app-icon {
+  width: 68px;
+  height: 68px;
+  border-radius: 20px;
+}
+
+.ios-dock-app .ios-app-title {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.85rem;
+}
+
+.ios-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  padding: 1.5rem;
+}
+
+.ios-modal {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2rem;
+  width: min(420px, 100%);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ios-modal-title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.ios-modal-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.ios-modal-input {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.ios-modal-input:focus {
+  outline: 2px solid rgba(0, 122, 255, 0.25);
+}
+
+.ios-modal-color {
+  border-radius: 12px;
+  height: 44px;
+  border: none;
+  cursor: pointer;
+}
+
+.ios-modal-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.ios-modal-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1024px) {
+  .ios-top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+
+  .ios-controls {
+    align-self: stretch;
+    justify-content: space-between;
+  }
+
+  .ios-screen {
+    padding: 2rem;
+  }
+
+  .ios-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .ios-status-bar {
+    padding: 1rem 1.5rem 0.25rem;
+  }
+
+  .ios-top-bar {
+    padding: 1.5rem 1.5rem 1rem;
+  }
+
+  .ios-screen-wrapper {
+    width: 94vw;
+    height: clamp(400px, 60vh, 520px);
+  }
+
+  .ios-grid {
+    gap: 1.5rem 1.25rem;
+  }
+
+  .ios-dock {
+    height: 96px;
+    width: min(560px, 90vw);
+    bottom: 24px;
+  }
+
+  .ios-dock-inner {
+    gap: 1.2rem;
+    padding: 1.1rem 1.6rem;
+  }
+
+  .ios-dock-app .ios-app-icon {
+    width: 58px;
+    height: 58px;
+  }
+}
+
+@media (max-width: 540px) {
+  .ios-screen-wrapper {
+    border-radius: 24px;
+    height: clamp(380px, 65vh, 480px);
+  }
+
+  .ios-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem 1rem;
+  }
+
+  .ios-app-icon {
+    width: 68px;
+    height: 68px;
+    border-radius: 20px;
+  }
+
+  .ios-app-title {
+    font-size: 0.85rem;
+  }
+
+  .ios-dock {
+    width: min(460px, 92vw);
+    border-radius: 26px;
+  }
+
+  .ios-dock-app .ios-app-title {
+    display: none;
+  }
+}

--- a/client/src/pages/dashboard/IpadWorkspace.css
+++ b/client/src/pages/dashboard/IpadWorkspace.css
@@ -1,458 +1,431 @@
-.ios-workspace {
+.workspace {
   position: relative;
   min-height: 100vh;
-  width: 100%;
-  overflow: hidden;
-  background: #ffffff;
+  background: radial-gradient(circle at 20% 20%, rgba(0, 122, 255, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(255, 149, 0, 0.12), transparent 60%),
+    linear-gradient(160deg, #f5f5f5 0%, #ffffff 45%, #e8f0ff 100%);
+  padding: 72px 6vw 160px;
+  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #000000;
-  font-family: 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif;
+  overflow: hidden;
 }
 
-.ios-background {
+.workspace::before {
+  content: '';
   position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top, rgba(0, 122, 255, 0.18), transparent 55%),
-    radial-gradient(circle at bottom, rgba(52, 199, 89, 0.16), transparent 60%),
-    linear-gradient(145deg, #ffffff 0%, #f5f5f5 100%);
+  top: -180px;
+  right: -120px;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle, rgba(52, 199, 89, 0.2), transparent 70%);
+  filter: blur(10px);
   z-index: 0;
 }
 
-.ios-status-bar {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.5rem 3rem 0.5rem;
-  color: #000000;
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-}
-
-.ios-status-icons {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.ios-status-dot {
-  width: 0.6rem;
-  height: 0.6rem;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.5);
-}
-
-.ios-status-battery {
-  font-variation-settings: 'wght' 550;
-}
-
-.ios-top-bar {
+.workspace-header {
   position: relative;
   z-index: 1;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 2rem 3rem 1rem;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 40px;
 }
 
-.ios-title {
+.workspace-subtitle {
   margin: 0;
-  font-size: clamp(2rem, 4vw, 2.75rem);
-  font-weight: 600;
-}
-
-.ios-subtitle {
-  margin: 0.25rem 0 0;
+  font-size: 14px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
   color: rgba(0, 0, 0, 0.55);
-  font-size: 1rem;
 }
 
-.ios-controls {
+.workspace-title {
+  margin: 6px 0 0;
+  font-size: clamp(32px, 4vw, 44px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.screen-indicators {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 12px;
 }
 
-.ios-control-button {
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 12px;
-  border: none;
-  background: rgba(245, 245, 245, 0.85);
-  color: #000000;
-  font-size: 1.75rem;
-  line-height: 1;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.1);
-}
-
-.ios-control-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
-}
-
-.ios-primary-button {
-  border: none;
-  border-radius: 12px;
-  background: #007aff;
-  color: #ffffff;
-  font-weight: 600;
-  padding: 0.75rem 1.5rem;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-  box-shadow: 0 12px 30px rgba(0, 122, 255, 0.35);
-}
-
-.ios-primary-button:hover {
-  background: #0062c4;
-  transform: translateY(-1px);
-}
-
-.ios-secondary-button {
-  border: none;
-  border-radius: 12px;
-  background: rgba(0, 0, 0, 0.08);
-  color: #000000;
-  font-weight: 500;
-  padding: 0.75rem 1.5rem;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.ios-secondary-button:hover {
-  background: rgba(0, 0, 0, 0.12);
-}
-
-.ios-screen-wrapper {
-  position: relative;
-  z-index: 1;
-  margin: 0 auto;
-  width: min(1200px, 92vw);
-  height: clamp(440px, 55vh, 560px);
-  border-radius: 32px;
-  overflow: hidden;
-  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.15);
-  background: rgba(255, 255, 255, 0.8);
-  backdrop-filter: blur(18px);
-  cursor: grab;
-}
-
-.ios-screen-wrapper:active {
-  cursor: grabbing;
-}
-
-.ios-screen-track {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  transition: transform 0.45s ease;
-}
-
-.ios-screen {
-  min-width: 100%;
-  height: 100%;
-  padding: 2.5rem 3rem;
-  box-sizing: border-box;
-}
-
-.ios-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 2rem 1.75rem;
-  justify-items: center;
-}
-
-.ios-app {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: inherit;
-}
-
-.ios-app-icon {
-  width: 82px;
-  height: 82px;
-  border-radius: 24px;
-  position: relative;
-  background-size: cover;
-  display: grid;
-  place-items: center;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
-  overflow: hidden;
-}
-
-.ios-app-shine {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 55%);
-  pointer-events: none;
-}
-
-.ios-app-initials {
-  position: relative;
-  z-index: 1;
-  color: rgba(255, 255, 255, 0.95);
-  font-size: 1.5rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
-.ios-app-title {
-  font-size: 0.95rem;
-  font-weight: 500;
-  text-align: center;
-  color: rgba(0, 0, 0, 0.8);
-}
-
-.ios-page-indicator {
-  z-index: 1;
-  margin: 1.5rem 0;
-  display: flex;
-  justify-content: center;
-  gap: 0.75rem;
-}
-
-.ios-page-dot {
-  width: 12px;
-  height: 12px;
+.screen-indicator {
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   border: none;
-  background: rgba(0, 0, 0, 0.18);
-  padding: 0;
+  background: rgba(44, 44, 44, 0.18);
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.35);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
-.ios-page-dot-active {
+.screen-indicator.active {
   background: #007aff;
   transform: scale(1.2);
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
 }
 
-.ios-dock {
+.screens-wrapper {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  border-radius: 36px;
+  background: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(30px);
+  -webkit-backdrop-filter: blur(30px);
+}
+
+.screens-track {
+  display: flex;
+  width: 100%;
+  transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.workspace-screen {
+  min-width: 100%;
+  padding: 48px 60px 72px;
+  box-sizing: border-box;
+}
+
+.bookmark-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 36px 32px;
+}
+
+.bookmark-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+}
+
+.bookmark-icon {
+  width: 110px;
+  height: 110px;
+  border-radius: 26px;
+  border: none;
+  box-shadow: 0 20px 35px rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-size: 38px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  cursor: pointer;
+}
+
+.bookmark-icon-symbol {
+  font-size: 38px;
+  line-height: 1;
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.2));
+}
+
+.bookmark-icon:hover {
+  transform: translateY(-6px) scale(1.04);
+  box-shadow: 0 24px 40px rgba(0, 0, 0, 0.2);
+}
+
+.bookmark-label {
+  font-size: 16px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.add-bookmark-button {
+  position: fixed;
+  top: 32px;
+  right: 32px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: none;
+  background: #007aff;
+  color: #ffffff;
+  font-size: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 18px 36px rgba(0, 122, 255, 0.35);
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  z-index: 3;
+}
+
+.add-bookmark-button:hover {
+  transform: translateY(-4px) scale(1.05);
+  box-shadow: 0 24px 42px rgba(0, 122, 255, 0.4);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 15, 0.35);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 4;
+}
+
+.modal-card {
+  width: min(440px, 100%);
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  padding: 34px 36px;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.modal-card h2 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.modal-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.modal-card input {
+  height: 48px;
+  border-radius: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0 16px;
+  font-size: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.04);
+}
+
+.modal-card input:focus {
+  outline: 2px solid rgba(0, 122, 255, 0.25);
+  box-shadow: 0 0 0 4px rgba(0, 122, 255, 0.08);
+}
+
+.color-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.color-picker span {
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.color-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.color-swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.color-swatch.selected {
+  border-color: #ffffff;
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.16);
+  transform: scale(1.08);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 14px;
+  margin-top: 12px;
+}
+
+.btn-primary,
+.btn-secondary {
+  min-width: 120px;
+  height: 46px;
+  border-radius: 14px;
+  font-size: 15px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  background: #007aff;
+  color: #ffffff;
+  box-shadow: 0 14px 28px rgba(0, 122, 255, 0.32);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(0, 122, 255, 0.35);
+}
+
+.btn-secondary {
+  background: rgba(44, 44, 44, 0.08);
+  color: rgba(44, 44, 44, 0.85);
+}
+
+.btn-secondary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.1);
+}
+
+.dock {
   position: fixed;
   left: 50%;
   bottom: 32px;
   transform: translateX(-50%);
-  width: min(720px, 90vw);
-  height: 116px;
+  padding: 18px 28px;
   border-radius: 32px;
+  background: rgba(44, 44, 44, 0.75);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   display: flex;
+  align-items: flex-end;
+  gap: 18px;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.28);
+  z-index: 2;
+}
+
+.dock-app {
+  width: 72px;
+  height: 84px;
+  padding: 12px 8px 10px;
+  border-radius: 22px;
+  border: none;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  z-index: 3;
-}
-
-.ios-dock-blur {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: rgba(44, 44, 44, 0.72);
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(26px);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.ios-dock-inner {
-  position: relative;
-  display: flex;
-  gap: 1.75rem;
-  padding: 1.5rem 2.5rem;
-  z-index: 1;
-}
-
-.ios-dock-app {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  background: transparent;
-  border: none;
-  color: rgba(255, 255, 255, 0.85);
+  gap: 8px;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
   cursor: pointer;
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.ios-dock-app .ios-app-icon {
-  width: 68px;
-  height: 68px;
-  border-radius: 20px;
+.dock-app:hover {
+  transform: translateY(-6px) scale(1.05);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.3);
 }
 
-.ios-dock-app .ios-app-title {
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 0.85rem;
+.dock-icon {
+  font-size: 28px;
 }
 
-.ios-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(8px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10;
-  padding: 1.5rem;
-}
-
-.ios-modal {
-  background: #ffffff;
-  border-radius: 24px;
-  padding: 2rem;
-  width: min(420px, 100%);
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.18);
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.ios-modal-title {
-  margin: 0;
-  font-size: 1.6rem;
-  font-weight: 600;
-}
-
-.ios-modal-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.95rem;
-  color: rgba(0, 0, 0, 0.75);
-}
-
-.ios-modal-input {
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 12px;
-  padding: 0.65rem 0.85rem;
-  font-size: 1rem;
-  font-family: inherit;
-}
-
-.ios-modal-input:focus {
-  outline: 2px solid rgba(0, 122, 255, 0.25);
-}
-
-.ios-modal-color {
-  border-radius: 12px;
-  height: 44px;
-  border: none;
-  cursor: pointer;
-}
-
-.ios-modal-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  font-size: 0.95rem;
-  color: rgba(0, 0, 0, 0.75);
-}
-
-.ios-modal-actions {
-  margin-top: 0.5rem;
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.75rem;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+.dock-label {
+  font-size: 12px;
+  font-weight: 500;
 }
 
 @media (max-width: 1024px) {
-  .ios-top-bar {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1.5rem;
+  .workspace {
+    padding: 64px 5vw 150px;
   }
 
-  .ios-controls {
-    align-self: stretch;
-    justify-content: space-between;
+  .workspace-screen {
+    padding: 36px 32px 60px;
   }
 
-  .ios-screen {
-    padding: 2rem;
+  .bookmark-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 28px;
   }
 
-  .ios-grid {
-    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  .bookmark-icon {
+    width: 96px;
+    height: 96px;
+    font-size: 32px;
   }
 }
 
 @media (max-width: 768px) {
-  .ios-status-bar {
-    padding: 1rem 1.5rem 0.25rem;
+  .workspace {
+    padding: 64px 24px 140px;
   }
 
-  .ios-top-bar {
-    padding: 1.5rem 1.5rem 1rem;
+  .workspace-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
   }
 
-  .ios-screen-wrapper {
-    width: 94vw;
-    height: clamp(400px, 60vh, 520px);
+  .screens-wrapper {
+    border-radius: 28px;
   }
 
-  .ios-grid {
-    gap: 1.5rem 1.25rem;
+  .workspace-screen {
+    padding: 32px 24px 52px;
   }
 
-  .ios-dock {
-    height: 96px;
-    width: min(560px, 90vw);
+  .bookmark-grid {
+    grid-template-columns: repeat(3, minmax(90px, 1fr));
+    gap: 24px;
+  }
+
+  .dock {
+    width: calc(100% - 48px);
     bottom: 24px;
+    padding: 16px 20px;
+    justify-content: space-around;
   }
 
-  .ios-dock-inner {
-    gap: 1.2rem;
-    padding: 1.1rem 1.6rem;
+  .dock-app {
+    flex: 1;
+    max-width: 64px;
+    height: 78px;
   }
 
-  .ios-dock-app .ios-app-icon {
-    width: 58px;
-    height: 58px;
+  .add-bookmark-button {
+    top: 24px;
+    right: 24px;
   }
 }
 
 @media (max-width: 540px) {
-  .ios-screen-wrapper {
-    border-radius: 24px;
-    height: clamp(380px, 65vh, 480px);
+  .bookmark-grid {
+    grid-template-columns: repeat(3, minmax(82px, 1fr));
+    gap: 20px;
   }
 
-  .ios-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.25rem 1rem;
-  }
-
-  .ios-app-icon {
-    width: 68px;
-    height: 68px;
+  .bookmark-icon {
+    width: 82px;
+    height: 82px;
     border-radius: 20px;
+    font-size: 28px;
   }
 
-  .ios-app-title {
-    font-size: 0.85rem;
+  .bookmark-label {
+    font-size: 14px;
   }
 
-  .ios-dock {
-    width: min(460px, 92vw);
-    border-radius: 26px;
-  }
-
-  .ios-dock-app .ios-app-title {
-    display: none;
+  .dock {
+    bottom: 16px;
+    border-radius: 28px;
   }
 }

--- a/client/src/pages/dashboard/IpadWorkspace.js
+++ b/client/src/pages/dashboard/IpadWorkspace.js
@@ -1,0 +1,476 @@
+import React, { useMemo, useRef, useState } from 'react';
+import './IpadWorkspace.css';
+
+const getId = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const clampIndex = (index, length) => {
+  if (index < 0) return 0;
+  if (index >= length) return length - 1;
+  return index;
+};
+
+const lightenDarkenColor = (hex, amt) => {
+  let col = hex.replace('#', '');
+
+  if (col.length === 3) {
+    col = col.split('').map((c) => c + c).join('');
+  }
+
+  const num = parseInt(col, 16);
+  let r = (num >> 16) + amt;
+  let g = ((num >> 8) & 0x00ff) + amt;
+  let b = (num & 0x0000ff) + amt;
+
+  r = Math.max(Math.min(255, r), 0);
+  g = Math.max(Math.min(255, g), 0);
+  b = Math.max(Math.min(255, b), 0);
+
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+};
+
+const createGradient = (baseColor) => {
+  const light = lightenDarkenColor(baseColor, 40);
+  const dark = lightenDarkenColor(baseColor, -40);
+  return `linear-gradient(135deg, ${light}, ${dark})`;
+};
+
+const DEFAULT_SCREENS = [
+  {
+    id: 'screen-1',
+    name: 'Productivity',
+    bookmarks: [
+      {
+        id: 'bookmark-1',
+        title: 'Agri Market',
+        url: 'https://example.com/market',
+        color: '#007AFF',
+      },
+      {
+        id: 'bookmark-2',
+        title: 'Weather',
+        url: 'https://weather.com',
+        color: '#34C759',
+      },
+      {
+        id: 'bookmark-3',
+        title: 'Analytics',
+        url: 'https://analytics.google.com',
+        color: '#FF9500',
+      },
+      {
+        id: 'bookmark-4',
+        title: 'Docs',
+        url: 'https://docs.google.com',
+        color: '#AF52DE',
+      },
+      {
+        id: 'bookmark-5',
+        title: 'Community',
+        url: 'https://community.example.com',
+        color: '#FF3B30',
+      },
+      {
+        id: 'bookmark-6',
+        title: 'News',
+        url: 'https://news.ycombinator.com',
+        color: '#FF2D55',
+      },
+    ],
+  },
+  {
+    id: 'screen-2',
+    name: 'Innovation',
+    bookmarks: [
+      {
+        id: 'bookmark-7',
+        title: 'AI Research',
+        url: 'https://ai.google',
+        color: '#5AC8FA',
+      },
+      {
+        id: 'bookmark-8',
+        title: 'Sustainability',
+        url: 'https://sdgs.un.org',
+        color: '#FFCC00',
+      },
+      {
+        id: 'bookmark-9',
+        title: 'Funding',
+        url: 'https://funding.example.com',
+        color: '#5856D6',
+      },
+      {
+        id: 'bookmark-10',
+        title: 'Design',
+        url: 'https://dribbble.com',
+        color: '#FF9F0A',
+      },
+      {
+        id: 'bookmark-11',
+        title: 'Climate',
+        url: 'https://climate.nasa.gov',
+        color: '#32ADE6',
+      },
+      {
+        id: 'bookmark-12',
+        title: 'Inspiration',
+        url: 'https://behance.net',
+        color: '#AF52DE',
+      },
+    ],
+  },
+  {
+    id: 'screen-3',
+    name: 'Focus',
+    bookmarks: [
+      {
+        id: 'bookmark-13',
+        title: 'Calm',
+        url: 'https://calm.com',
+        color: '#30B0C7',
+      },
+      {
+        id: 'bookmark-14',
+        title: 'Notes',
+        url: 'https://keep.google.com',
+        color: '#FFD60A',
+      },
+      {
+        id: 'bookmark-15',
+        title: 'Music',
+        url: 'https://music.apple.com',
+        color: '#FF375F',
+      },
+      {
+        id: 'bookmark-16',
+        title: 'Focus Docs',
+        url: 'https://notion.so',
+        color: '#5856D6',
+      },
+      {
+        id: 'bookmark-17',
+        title: 'Read Later',
+        url: 'https://raindrop.io',
+        color: '#007AFF',
+      },
+      {
+        id: 'bookmark-18',
+        title: 'Tasks',
+        url: 'https://todoist.com',
+        color: '#FF453A',
+      },
+    ],
+  },
+];
+
+const DEFAULT_DOCK = [
+  {
+    id: 'dock-1',
+    title: 'Mail',
+    url: 'https://mail.google.com',
+    color: '#007AFF',
+  },
+  {
+    id: 'dock-2',
+    title: 'Calendar',
+    url: 'https://calendar.google.com',
+    color: '#FF9500',
+  },
+  {
+    id: 'dock-3',
+    title: 'Files',
+    url: 'https://drive.google.com',
+    color: '#34C759',
+  },
+  {
+    id: 'dock-4',
+    title: 'Messages',
+    url: 'https://messages.google.com',
+    color: '#5856D6',
+  },
+];
+
+const IpadWorkspace = () => {
+  const [screens, setScreens] = useState(DEFAULT_SCREENS);
+  const [dockItems, setDockItems] = useState(DEFAULT_DOCK);
+  const [activeScreen, setActiveScreen] = useState(0);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [addToDock, setAddToDock] = useState(false);
+  const [bookmarkForm, setBookmarkForm] = useState({
+    title: '',
+    url: '',
+    color: '#007AFF',
+  });
+
+  const dragStartRef = useRef(null);
+  const isDraggingRef = useRef(false);
+
+  const computedScreens = useMemo(
+    () =>
+      screens.map((screen) => ({
+        ...screen,
+        bookmarks: screen.bookmarks.map((bookmark) => ({
+          ...bookmark,
+          gradient: createGradient(bookmark.color),
+        })),
+      })),
+    [screens]
+  );
+
+  const computedDock = useMemo(
+    () =>
+      dockItems.map((bookmark) => ({
+        ...bookmark,
+        gradient: createGradient(bookmark.color),
+      })),
+    [dockItems]
+  );
+
+  const handleScreenChange = (nextIndex) => {
+    setActiveScreen((current) => clampIndex(nextIndex, screens.length));
+  };
+
+  const handlePointerStart = (clientX) => {
+    dragStartRef.current = clientX;
+    isDraggingRef.current = true;
+  };
+
+  const handlePointerEnd = (clientX) => {
+    if (!isDraggingRef.current || dragStartRef.current === null) return;
+
+    const delta = clientX - dragStartRef.current;
+    if (Math.abs(delta) > 60) {
+      if (delta < 0) {
+        handleScreenChange(activeScreen + 1);
+      } else {
+        handleScreenChange(activeScreen - 1);
+      }
+    }
+    dragStartRef.current = null;
+    isDraggingRef.current = false;
+  };
+
+  const handleTouchStart = (event) => {
+    const touch = event.touches[0];
+    handlePointerStart(touch.clientX);
+  };
+
+  const handleTouchEnd = (event) => {
+    const touch = event.changedTouches[0];
+    handlePointerEnd(touch.clientX);
+  };
+
+  const handleMouseDown = (event) => {
+    handlePointerStart(event.clientX);
+  };
+
+  const handleMouseUp = (event) => {
+    handlePointerEnd(event.clientX);
+  };
+
+  const handleBookmarkClick = (bookmark) => {
+    window.open(bookmark.url, '_blank', 'noopener,noreferrer');
+  };
+
+  const openAddModal = () => {
+    setBookmarkForm({ title: '', url: '', color: '#007AFF' });
+    setAddToDock(false);
+    setShowAddModal(true);
+  };
+
+  const handleFormChange = (event) => {
+    const { name, value } = event.target;
+    setBookmarkForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!bookmarkForm.title.trim() || !bookmarkForm.url.trim()) {
+      return;
+    }
+
+    const newBookmark = {
+      id: getId(),
+      title: bookmarkForm.title.trim(),
+      url: bookmarkForm.url.trim(),
+      color: bookmarkForm.color,
+    };
+
+    setScreens((prev) =>
+      prev.map((screen, index) => {
+        if (index !== activeScreen) return screen;
+        return {
+          ...screen,
+          bookmarks: [...screen.bookmarks, newBookmark],
+        };
+      })
+    );
+
+    if (addToDock) {
+      setDockItems((prev) => [...prev, { ...newBookmark, id: getId() }]);
+    }
+
+    setShowAddModal(false);
+  };
+
+  const activeScreenName = screens[activeScreen]?.name ?? 'Workspace';
+
+  return (
+    <div className="ios-workspace">
+      <div className="ios-background" />
+      <div className="ios-status-bar">
+        <div className="ios-status-time">{new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
+        <div className="ios-status-icons">
+          <span className="ios-status-dot" />
+          <span className="ios-status-dot" />
+          <span className="ios-status-battery">100%</span>
+        </div>
+      </div>
+
+      <div className="ios-top-bar">
+        <div>
+          <h1 className="ios-title">{activeScreenName}</h1>
+          <p className="ios-subtitle">Swipe or use the arrows to move between spaces</p>
+        </div>
+        <div className="ios-controls">
+          <button type="button" className="ios-control-button" onClick={() => handleScreenChange(activeScreen - 1)} aria-label="Previous workspace">
+            ‹
+          </button>
+          <button type="button" className="ios-control-button" onClick={() => handleScreenChange(activeScreen + 1)} aria-label="Next workspace">
+            ›
+          </button>
+          <button type="button" className="ios-primary-button" onClick={openAddModal}>
+            + Add Bookmark
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="ios-screen-wrapper"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+      >
+        <div className="ios-screen-track" style={{ transform: `translateX(-${activeScreen * 100}%)` }}>
+          {computedScreens.map((screen) => (
+            <div key={screen.id} className="ios-screen">
+              <div className="ios-grid">
+                {screen.bookmarks.map((bookmark) => (
+                  <button
+                    key={bookmark.id}
+                    type="button"
+                    className="ios-app"
+                    onClick={() => handleBookmarkClick(bookmark)}
+                  >
+                    <span className="ios-app-icon" style={{ backgroundImage: bookmark.gradient }}>
+                      <span className="ios-app-shine" />
+                      <span className="ios-app-initials">{bookmark.title.slice(0, 2).toUpperCase()}</span>
+                    </span>
+                    <span className="ios-app-title">{bookmark.title}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="ios-page-indicator" role="tablist" aria-label="Workspace selector">
+        {screens.map((screen, index) => (
+          <button
+            key={screen.id}
+            type="button"
+            role="tab"
+            aria-selected={index === activeScreen}
+            className={`ios-page-dot ${index === activeScreen ? 'ios-page-dot-active' : ''}`}
+            onClick={() => handleScreenChange(index)}
+          >
+            <span className="sr-only">{screen.name}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="ios-dock">
+        <div className="ios-dock-blur" />
+        <div className="ios-dock-inner">
+          {computedDock.map((bookmark) => (
+            <button
+              key={bookmark.id}
+              type="button"
+              className="ios-dock-app"
+              onClick={() => handleBookmarkClick(bookmark)}
+            >
+              <span className="ios-app-icon" style={{ backgroundImage: bookmark.gradient }}>
+                <span className="ios-app-shine" />
+                <span className="ios-app-initials">{bookmark.title.slice(0, 2).toUpperCase()}</span>
+              </span>
+              <span className="ios-app-title">{bookmark.title}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {showAddModal && (
+        <div className="ios-modal-backdrop" role="dialog" aria-modal="true">
+          <form className="ios-modal" onSubmit={handleSubmit}>
+            <h2 className="ios-modal-title">Add Bookmark</h2>
+            <label className="ios-modal-label" htmlFor="bookmarkTitle">
+              Title
+              <input
+                id="bookmarkTitle"
+                type="text"
+                name="title"
+                className="ios-modal-input"
+                value={bookmarkForm.title}
+                onChange={handleFormChange}
+                required
+              />
+            </label>
+            <label className="ios-modal-label" htmlFor="bookmarkUrl">
+              URL
+              <input
+                id="bookmarkUrl"
+                type="url"
+                name="url"
+                className="ios-modal-input"
+                value={bookmarkForm.url}
+                onChange={handleFormChange}
+                required
+              />
+            </label>
+            <label className="ios-modal-label" htmlFor="bookmarkColor">
+              Accent Color
+              <input
+                id="bookmarkColor"
+                type="color"
+                name="color"
+                className="ios-modal-color"
+                value={bookmarkForm.color}
+                onChange={handleFormChange}
+              />
+            </label>
+            <label className="ios-modal-checkbox">
+              <input
+                type="checkbox"
+                checked={addToDock}
+                onChange={(event) => setAddToDock(event.target.checked)}
+              />
+              <span>Add to dock</span>
+            </label>
+            <div className="ios-modal-actions">
+              <button type="button" className="ios-secondary-button" onClick={() => setShowAddModal(false)}>
+                Cancel
+              </button>
+              <button type="submit" className="ios-primary-button">
+                Save Bookmark
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IpadWorkspace;


### PR DESCRIPTION
## Summary
- add an iPadOS-inspired workspace page with swipeable multi-screen app grids, interactive dock, and bookmark creation modal
- apply frosted-glass and responsive styling that mimics iOS design language for app icons, dock, and modal controls
- expose the immersive workspace through a new `/workspace` application route

## Testing
- npm run build *(fails: react-scripts is unavailable because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6814efcc832e959f78bff9defddc